### PR TITLE
explicit intent for binding to billing-service

### DIFF
--- a/library/src/main/java/com/github/jberkel/pay/me/IabHelper.java
+++ b/library/src/main/java/com/github/jberkel/pay/me/IabHelper.java
@@ -85,7 +85,7 @@ import static com.github.jberkel.pay.me.model.ItemType.SUBS;
  * @author Jan Berkel
  */
 public class IabHelper {
-    /* package */ static final Intent BIND_BILLING_SERVICE = new Intent("com.android.vending.billing.InAppBillingService.BIND");
+    /* package */ static final Intent BIND_BILLING_SERVICE = new Intent("com.android.vending.billing.InAppBillingService.BIND").setPackage("com.android.vending");
 
     private Context mContext;
     private IInAppBillingService mService;


### PR DESCRIPTION
needed if you're targetting newer versions of the sdk